### PR TITLE
BUNBP-86 Changed parent exception for custom InvalidPasswordException

### DIFF
--- a/Exception/InvalidPasswordException.php
+++ b/Exception/InvalidPasswordException.php
@@ -5,8 +5,8 @@
 
 namespace Vendic\AdminPasswordPolicy\Exception;
 
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Validator\Exception;
 
-class InvalidPasswordException extends LocalizedException
+class InvalidPasswordException extends Exception
 {
 }


### PR DESCRIPTION
## Description
Investigated and fixed an issue with redirection on the admin password reset page if the password does not pass custom password validation rules.

## How Has This Been Tested?
1. Go to the admin login page.
2. Click "Forgot your password?" link and enter admin email address.
3. Follow the link in the email and enter a password that does not meet custom validation rules (for example, enter a new password without uppercase letters or special characters).
4. Submit the form and see if the page is the same and errors appear.

## Checklist:
- [x] Admin Password Policy extension works as expected.

## Changelog
### Fixed
- [BUNBP-86](https://app.clickup.com/t/6651913/BUNBP-86) Changed parent exception of `InvalidPassowordException` to avoid redirecting the page when submitting an invalid new password.